### PR TITLE
Add download directory access

### DIFF
--- a/com.atlauncher.ATLauncher.yml
+++ b/com.atlauncher.ATLauncher.yml
@@ -21,6 +21,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-download # Added due to Curseforge mod download workaround
 
 modules:
     # Needed by Minecraft 1.8.2 and up


### PR DESCRIPTION
CurseForge is now requiring some mod downloads from browser,
 The workaround monitors the download directory for the downloaded file.