### PR TITLE
Adding Launcher Graphics Java Workaround

### DIFF
--- a/com.atlauncher.ATLauncher.yml
+++ b/com.atlauncher.ATLauncher.yml
@@ -15,6 +15,7 @@ build-options:
 
 finish-args:
   - --env=PATH=/app/jre/bin:/usr/bin:/app/bin
+  - --env=_JAVA_AWT_WM_NONREPARENTING=1
   - --socket=x11
   - --share=ipc
   - --device=all


### PR DESCRIPTION
Adding _JAVA_AWT_WM_NONREPARENTING=1 to the Enviroment Variables of the Flatpak to generally circumvent any Graphical Issues. This for example fixes ATLauncher in Gamemode on the SteamDeck.
See https://github.com/ATLauncher/ATLauncher/issues/373 for details