### PR TITLE
Add req rec sup to metainfo

### DIFF
--- a/com.atlauncher.ATLauncher.metainfo.xml
+++ b/com.atlauncher.ATLauncher.metainfo.xml
@@ -67,8 +67,19 @@
         <screenshot>
             <image type="source" width="1186" height="693">https://atlauncher.com/assets/images/features/settings.png</image>
         </screenshot>
-    </screenshots>
-    
+	</screenshots>
+	<recommends>
+		<memory>4096</memory>
+		<internet>always</internet>
+	</recommends>
+	<requires>
+		<control>pointing</control>
+		<control>keyboard</control>
+		<internet>first-run</internet>
+	</requires>
+	<supports>
+		<control>gamepad</control>
+	</supports>
   <releases>
         <release version="3.4.20.1" date="2022-08-09"/>
         <release version="3.4.20.0" date="2022-08-06"/>


### PR DESCRIPTION
Add recommends, requires, and supports to the meta info. This is to ensure that ATLauncher receives expected things,  and prevents installs on devices without a keyboard.